### PR TITLE
All buttons added to example + Refactored code in src/buttons

### DIFF
--- a/example/lib/components/buttons.dart
+++ b/example/lib/components/buttons.dart
@@ -1,4 +1,5 @@
 import 'package:example/widgets/custom_snackbar.dart';
+import 'package:example/widgets/text.dart';
 import 'package:modular_ui/modular_ui.dart';
 import 'package:flutter/material.dart';
 
@@ -37,50 +38,230 @@ class _ButtonsViewState extends State<ButtonsView> {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: <Widget>[
-        MUIPrimaryButton(
-          text: "Primary Button",
-          onPressed: () => onButtonPressed("Primary Button"),
-        ),
-        const SizedBox(height: 10.0),
-        MUILoadingButton(
-          text: "Loading Button",
-          onPressed: () async {},
-          loadingStateText: "loading...",
-        ),
-        const SizedBox(height: 5),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            MUIRadioButton(
-              checked: radioButton,
-              onChanged: (value) {
-                radioButton = value;
-                setState(() {});
-              },
+    return SingleChildScrollView(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          /// Primary Button
+          text("Primary Button"),
+          const SizedBox(height: 6),
+          MUIPrimaryButton(
+            text: "Primary Button",
+            onPressed: () => onButtonPressed("Primary Button"),
+          ),
+          const SizedBox(height: 16.0),
+
+          /// Primary Button with Icon
+          text("Primary Button with Icon"),
+          const SizedBox(height: 6),
+          MUIPrimaryButton(
+            text: "Primary Button",
+            onPressed: () => onButtonPressed("Primary Button"),
+            leadingIcon: Icons.add,
+          ),
+          const SizedBox(height: 16.0),
+
+          /// Outlined Button
+          text("Outline Button"),
+          const SizedBox(height: 6),
+          MUIOutlinedButton(
+            text: "Outline Button",
+            onPressed: () => onButtonPressed("Outline Button"),
+          ),
+          const SizedBox(height: 16.0),
+
+          /// Loading Button
+          text("Loading Button"),
+          const SizedBox(height: 6),
+          MUILoadingButton(
+            text: "Loading Button",
+            onPressed: () async {
+              await Future.delayed(const Duration(seconds: 2));
+              onButtonPressed("Loading Button");
+            },
+            loadingStateText: "loading...",
+          ),
+          const SizedBox(height: 16.0),
+
+          /// Gradient Button
+          text("Gradient Button"),
+          const SizedBox(height: 6),
+          MUIGradientButton(
+            text: "Gradient Button",
+            onPressed: () => onButtonPressed("Gradient Button"),
+            bgGradient: const LinearGradient(
+              colors: [Color(0xFF4b6cb7), Color(0xFF182848)],
             ),
-            const SizedBox(width: 5),
-            MUIRadioButton.newYork(
-              checked: radioButton,
-              onChanged: (value) {
-                radioButton = value;
-                setState(() {});
-              },
+          ),
+          const SizedBox(height: 16.0),
+
+          /// Text Button
+          text("Text Button"),
+          const SizedBox(height: 6),
+          MUITextButton(
+            text: "Text Button",
+            onPressed: () => onButtonPressed("Text Button"),
+          ),
+          const SizedBox(height: 16.0),
+
+          /// Secondary Button
+          text("Secondary Button"),
+          const SizedBox(height: 6),
+          MUISecondaryButton(
+            text: "Secondary Button",
+            onPressed: () => onButtonPressed("Secondary Button"),
+          ),
+          const SizedBox(height: 16.0),
+
+          /// Secondary Outlined Button
+          text("Secondary Outlined Button"),
+          const SizedBox(height: 6),
+          MUISecondaryOutlinedButton(
+            text: "Secondary Outlined Button",
+            onPressed: () => onButtonPressed("Secondary Outline Button"),
+          ),
+          const SizedBox(height: 16.0),
+
+          /// Primary Block Button
+          text("Primary Block Button"),
+          const SizedBox(height: 6),
+          MUIPrimaryBlockButton(
+            text: "Primary Block Button",
+            onPressed: () => onButtonPressed("Primary Block Button"),
+          ),
+          const SizedBox(height: 16.0),
+
+          /// Outline Block Button
+          text("Outline Block Button"),
+          const SizedBox(height: 6),
+          MUIOutlinedBlockButton(
+            text: "Outline Block Button",
+            onPressed: () => onButtonPressed("Outline Block Button"),
+          ),
+          const SizedBox(height: 16.0),
+
+          /// Loading Block Button
+          text("Loading Block Button"),
+          const SizedBox(height: 6),
+          MUILoadingBlockButton(
+            text: "Loading Block Button",
+            onPressed: () async {
+              await Future.delayed(const Duration(seconds: 2));
+              onButtonPressed("Loading Block Button");
+            },
+            loadingStateText: "loading...",
+          ),
+          const SizedBox(height: 16.0),
+
+          /// Gradient Block Button
+          text("Gradient Block Button"),
+          const SizedBox(height: 6),
+          MUIGradientBlockButton(
+            text: "Gradient Block Button",
+            onPressed: () => onButtonPressed("Gradient Block Button"),
+            bgGradient: const LinearGradient(
+              colors: [Color(0xFF4b6cb7), Color(0xFF182848)],
             ),
-            const SizedBox(width: 5),
-            MUIRadioButton(
-              size: 50,
-              checked: radioButton,
-              onChanged: (value) {
-                radioButton = value;
-                setState(() {});
-              },
-            ),
-          ],
-        ),
-      ],
+          ),
+          const SizedBox(height: 16.0),
+
+          /// Text Block Button
+          text("Text Block Button"),
+          const SizedBox(height: 6),
+          MUITextBlockButton(
+            text: "Text Block Button",
+            onPressed: () => onButtonPressed("Text Block Button"),
+          ),
+          const SizedBox(height: 16.0),
+
+          /// Secondary Block Button
+          text("Secondary Block Button"),
+          const SizedBox(height: 6),
+          MUISecondaryBlockButton(
+            text: "Secondary Block Button",
+            onPressed: () => onButtonPressed("Secondary Block Button"),
+          ),
+          const SizedBox(height: 16.0),
+
+          /// Secondary Outlined Block Button
+          text("Secondary Outlined Block Button"),
+          const SizedBox(height: 6),
+          MUISecondaryOutlinedBlockButton(
+            text: "Secondary Outlined Block Button",
+            onPressed: () => onButtonPressed("Secondary Outlined Block Button"),
+          ),
+          const SizedBox(height: 16.0),
+
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            children: [
+              Column(
+                children: [
+                  /// Radio Buttons
+                  text("Radio Buttons"),
+                  const SizedBox(height: 6),
+                  MUIRadioButton(
+                    checked: radioButton,
+                    size: 50,
+                    onChanged: (value) {
+                      radioButton = value;
+                      setState(() {});
+                    },
+                  ),
+                  const SizedBox(height: 16.0),
+                ],
+              ),
+              Column(
+                children: [
+                  /// Radio Buttons new york
+                  text("Radio Buttons new york"),
+                  const SizedBox(height: 6),
+                  MUIRadioButton.newYork(
+                    checked: radioButton,
+                    size: 50,
+                    onChanged: (value) {
+                      radioButton = value;
+                      setState(() {});
+                    },
+                  ),
+                  const SizedBox(height: 16.0),
+                ],
+              )
+            ],
+          ),
+
+          // const SizedBox(height: 5),
+          // Row(
+          //   mainAxisAlignment: MainAxisAlignment.center,
+          //   children: <Widget>[
+          //     MUIRadioButton(
+          //       checked: radioButton,
+          //       onChanged: (value) {
+          //         radioButton = value;
+          //         setState(() {});
+          //       },
+          //     ),
+          //     const SizedBox(width: 5),
+          //     MUIRadioButton.newYork(
+          //       checked: radioButton,
+          //       onChanged: (value) {
+          //         radioButton = value;
+          //         setState(() {});
+          //       },
+          //     ),
+          //     const SizedBox(width: 5),
+          //     MUIRadioButton(
+          //       size: 50,
+          //       checked: radioButton,
+          //       onChanged: (value) {
+          //         radioButton = value;
+          //         setState(() {});
+          //       },
+          //     ),
+          //   ],
+          // ),
+        ],
+      ),
     );
   }
 }

--- a/example/lib/components/carousels.dart
+++ b/example/lib/components/carousels.dart
@@ -1,3 +1,4 @@
+import 'package:example/widgets/text.dart';
 import 'package:flutter/material.dart';
 import 'package:modular_ui/modular_ui.dart';
 
@@ -15,17 +16,6 @@ class _Carousels extends StatefulWidget {
 class __CarouselsState extends State<_Carousels> {
   @override
   Widget build(BuildContext context) {
-    Widget text(String text) {
-      return Text(
-        text,
-        style: const TextStyle(
-          color: Colors.black,
-          fontSize: 16,
-        ),
-        textAlign: TextAlign.center,
-      );
-    }
-
     return SingleChildScrollView(
       padding: const EdgeInsets.symmetric(vertical: 20),
       child: Column(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -15,7 +15,13 @@ class MyApp extends StatelessWidget {
       title: 'Example',
       debugShowCheckedModeBanner: false,
       theme: ThemeData(
-        primaryColor: Color(0xFFa2d2ff),
+        primaryColor: const Color(0xFFa2d2ff),
+        textTheme: const TextTheme(
+          displayMedium: TextStyle(
+            color: Colors.black,
+            fontSize: 16,
+          ),
+        ),
         useMaterial3: true,
       ),
       home: const Home(),

--- a/example/lib/widgets/text.dart
+++ b/example/lib/widgets/text.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+Widget text(String text) {
+  return Text(
+    text,
+    style: const TextStyle(
+      color: Colors.black,
+      fontSize: 16,
+    ),
+    textAlign: TextAlign.center,
+  );
+}

--- a/lib/src/buttons/gradient_block_level_button.dart
+++ b/lib/src/buttons/gradient_block_level_button.dart
@@ -3,8 +3,8 @@ import 'package:flutter/services.dart';
 import 'package:modular_ui/src/utils/dimensions.dart';
 
 /// A customizable gradient block level button by ModularUI with optional icons.
-class MUIGradientBlockLevelButton extends StatefulWidget {
-  const MUIGradientBlockLevelButton(
+class MUIGradientBlockButton extends StatefulWidget {
+  const MUIGradientBlockButton(
       {super.key,
       required this.text,
       required this.onPressed,
@@ -66,12 +66,12 @@ class MUIGradientBlockLevelButton extends StatefulWidget {
   final List<BoxShadow>? boxShadows;
 
   @override
-  State<MUIGradientBlockLevelButton> createState() =>
-      _MUIGradientBlockLevelButtonState();
+  State<MUIGradientBlockButton> createState() =>
+      _MUIGradientBlockButtonState();
 }
 
-class _MUIGradientBlockLevelButtonState
-    extends State<MUIGradientBlockLevelButton> {
+class _MUIGradientBlockButtonState
+    extends State<MUIGradientBlockButton> {
   bool _isGradientBlockLevelButtonPressed = false;
 
   @override

--- a/lib/src/buttons/loading_block_level_button.dart
+++ b/lib/src/buttons/loading_block_level_button.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:modular_ui/src/utils/dimensions.dart';
 
 /// A customizable loading block level button by ModularUI with optional icons.
-class MUILoadingBlockLevelButton extends StatefulWidget {
-  const MUILoadingBlockLevelButton({
+class MUILoadingBlockButton extends StatefulWidget {
+  const MUILoadingBlockButton({
     super.key,
     required this.text,
     required this.onPressed,
@@ -76,12 +76,12 @@ class MUILoadingBlockLevelButton extends StatefulWidget {
   final List<BoxShadow>? boxShadows;
 
   @override
-  State<MUILoadingBlockLevelButton> createState() =>
-      _MUILoadingBlockLevelButtonState();
+  State<MUILoadingBlockButton> createState() =>
+      _MUILoadingBlockButtonState();
 }
 
-class _MUILoadingBlockLevelButtonState
-    extends State<MUILoadingBlockLevelButton> {
+class _MUILoadingBlockButtonState
+    extends State<MUILoadingBlockButton> {
   bool _isLoadingBlockLevelButtonPressed = false;
 
   void _startLoading() {

--- a/lib/src/buttons/outlined_block_level_button.dart
+++ b/lib/src/buttons/outlined_block_level_button.dart
@@ -3,8 +3,8 @@ import 'package:flutter/services.dart';
 import 'package:modular_ui/src/utils/dimensions.dart';
 
 /// A customizable outlined block level button by ModularUI with optional icons.
-class MUIOutlinedBlockLevelButton extends StatefulWidget {
-  const MUIOutlinedBlockLevelButton({
+class MUIOutlinedBlockButton extends StatefulWidget {
+  const MUIOutlinedBlockButton({
     super.key,
     required this.text,
     required this.onPressed,
@@ -73,12 +73,12 @@ class MUIOutlinedBlockLevelButton extends StatefulWidget {
   final List<BoxShadow>? boxShadows;
 
   @override
-  State<MUIOutlinedBlockLevelButton> createState() =>
-      _MUIOutlinedBlockLevelButtonState();
+  State<MUIOutlinedBlockButton> createState() =>
+      _MUIOutlinedBlockButtonState();
 }
 
-class _MUIOutlinedBlockLevelButtonState
-    extends State<MUIOutlinedBlockLevelButton> {
+class _MUIOutlinedBlockButtonState
+    extends State<MUIOutlinedBlockButton> {
   bool _isOutlinedBlockLevelButtonPressed = false;
 
   @override

--- a/lib/src/buttons/secondary_button.dart
+++ b/lib/src/buttons/secondary_button.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 /// A customizable Secondary button by ModularUI with optional icons.
-class MUISeconaryButton extends StatefulWidget {
-  const MUISeconaryButton({
+class MUISecondaryButton extends StatefulWidget {
+  const MUISecondaryButton({
     Key? key,
     required this.text,
     required this.onPressed,
@@ -56,10 +56,10 @@ class MUISeconaryButton extends StatefulWidget {
   final List<BoxShadow>? boxShadows;
 
   @override
-  State<MUISeconaryButton> createState() => _MUISecondaryButtonState();
+  State<MUISecondaryButton> createState() => _MUISecondaryButtonState();
 }
 
-class _MUISecondaryButtonState extends State<MUISeconaryButton> {
+class _MUISecondaryButtonState extends State<MUISecondaryButton> {
   bool _isSecondaryButtonPressed = false;
 
   @override

--- a/lib/src/buttons/text_block_level_button.dart
+++ b/lib/src/buttons/text_block_level_button.dart
@@ -3,8 +3,8 @@ import 'package:flutter/services.dart';
 import 'package:modular_ui/src/utils/dimensions.dart';
 
 /// A customizable text block level button by ModularUI with optional icons.
-class MUITextBlockLevelButton extends StatefulWidget {
-  const MUITextBlockLevelButton({
+class MUITextBlockButton extends StatefulWidget {
+  const MUITextBlockButton({
     super.key,
     required this.text,
     required this.onPressed,
@@ -57,11 +57,10 @@ class MUITextBlockLevelButton extends StatefulWidget {
   final VoidCallback onPressed;
 
   @override
-  State<MUITextBlockLevelButton> createState() =>
-      _MUITextBlockLevelButtonState();
+  State<MUITextBlockButton> createState() => _MUITextBlockButtonState();
 }
 
-class _MUITextBlockLevelButtonState extends State<MUITextBlockLevelButton> {
+class _MUITextBlockButtonState extends State<MUITextBlockButton> {
   bool _isTextBlockLevelButtonPressed = false;
 
   @override

--- a/lib/src/cards/sign_in_card.dart
+++ b/lib/src/cards/sign_in_card.dart
@@ -155,7 +155,7 @@ class _MUISignInCardState extends State<MUISignInCard> {
             ),
             SizedBox(height: getScreenHeight(context) * 0.03),
             Center(
-              child: MUILoadingBlockLevelButton(
+              child: MUILoadingBlockButton(
                   text: 'Sign in',
                   bgColor: widget.accentColor,
                   textColor: widget.bgColor,

--- a/lib/src/cards/sign_up_card.dart
+++ b/lib/src/cards/sign_up_card.dart
@@ -177,7 +177,7 @@ class _MUISignUpCardState extends State<MUISignUpCard> {
             ),
             SizedBox(height: getScreenHeight(context) * 0.03),
             Center(
-              child: MUILoadingBlockLevelButton(
+              child: MUILoadingBlockButton(
                   text: 'Sign up',
                   bgColor: widget.accentColor,
                   textColor: widget.bgColor,


### PR DESCRIPTION
![WhatsApp Image 2024-01-21 at 17 55 17_668dabea](https://github.com/opxica/modular-ui/assets/67179751/71d4aa75-c360-49cb-a0f2-3b905356cf2b)
![WhatsApp Image 2024-01-21 at 17 55 18_dcbea424](https://github.com/opxica/modular-ui/assets/67179751/12c6357e-e8c8-4518-8b31-1ac5e83ed6b8)

This commit changes all 
%BlockLevelButton naming convention to %BlockButton (making it short and concise)