### PR TITLE
Implemented dropdown widgets

### DIFF
--- a/example/lib/components/dropdowns.dart
+++ b/example/lib/components/dropdowns.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:modular_ui/modular_ui.dart';
+
+Widget dropdown() {
+  return const DropdownView();
+}
+
+
+class DropdownView extends StatefulWidget {
+  const DropdownView({super.key});
+
+  @override
+  State<DropdownView> createState() => _DropdownViewState();
+}
+
+class _DropdownViewState extends State<DropdownView> {
+  Map<String, dynamic>? selectedMap;
+  String? selectedString;
+
+  List<Map<String, dynamic>> mapItems = [
+    {'id': 1, 'display': 'Item 1'},
+    {'id': 2, 'display': 'Item 2'},
+    {'id': 3, 'display': 'Item 3'},
+    {'id': 4, 'display': 'Item 4'},
+  ];
+  List<String> stringItems = ['Item 1', 'Item 2', 'Item 3'];
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: [
+            MUIPrimaryDropDown(
+              onItemSelected: (item) {
+                setState(() {
+                  selectedString = item;
+                });
+              },
+              borderRadius: 5,
+              hintIcon: const Icon(
+                Icons.arrow_drop_down_circle_outlined,
+                color: Colors.white,
+                size: 12,
+              ),
+              items: stringItems,
+              hintText: 'Select String',
+              hintStyle: TextStyle(color: Colors.grey.shade300),
+            ),
+             MUIMapDropDown(
+              mapKey: 'display',
+              onItemSelected: (item) {
+                setState(() {
+                  selectedMap = item;
+                });
+              },
+              borderRadius: 5,
+              hintIcon: const Icon(
+                Icons.arrow_drop_down_circle_outlined,
+                color: Colors.white,
+                size: 12,
+              ),
+              items: mapItems,
+              hintText: 'Select Map',
+              hintStyle: TextStyle(color: Colors.grey.shade300),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:example/components/dropdowns.dart';
 import 'package:flutter/material.dart';
 import 'package:example/components/avatar.dart';
 import 'package:example/components/breadcrumbs.dart';
@@ -74,6 +75,10 @@ class _HomeState extends State<Home> with SingleTickerProviderStateMixin {
       {
         'name': 'Dialog',
         'route': dialog(context),
+      },
+      {
+        'name': 'Dropdown',
+        'route': dropdown(),
       },
       {
         'name': 'Checkbox',


### PR DESCRIPTION
This PR Closes #136 

### Media 
[Screencast from 2024-02-14 02-53-07.webm](https://github.com/opxica/modular-ui/assets/71646773/2cc34a75-704e-4fe5-97c3-12822adb1d37)

This PR creates two widgets.
1. `MUIPrimaryDropdown`
- This widget takes a list of `String` as the items for droopdown

2. `MUIMapDropdown`
- This widget takes a list of `Map<String,dynamic>` as the items for droopdown
- This is useful for the case when a user wants to show data according to a `Map` fetched from some `web api`
- This also gives user way to select that map fro the list of maps.